### PR TITLE
compute po in php mode

### DIFF
--- a/PubRule
+++ b/PubRule
@@ -166,19 +166,33 @@ po:
 	perl -ne 'print "N_(\"$$1\")\n" while(m/\[TEXT:([^]]+)]/g)' {} \; \
 	> tempCatalog.php
 
-	find . -type f -name "*.php" -print0 | xargs -0 php -r 'array_walk(array_slice($$argv,1),function($$f){array_walk(preg_filter("/.*@(searchLabel)\\s+([^\\n]+)\\n.*/s","\\2",array_map(function($$t){return$$t[1];},array_filter(token_get_all(file_get_contents($$f)),function($$t){return($$t[0]==T_DOC_COMMENT);}))),function($$t){printf("N_(\"%s\")\n",preg_replace("/\"/","\\\"",$$t));});});' >> tempCatalog.php
+	find . -type f -name "*.php" -print0 | xargs -0 php -r 'array_walk( array_slice($$argv,1), function($$f){ array_walk( preg_filter( "/.*@(searchLabel)\\s+([^\\n]+)\\n.*/s", "\\2", array_map( function($$t){ return$$t[1]; }, array_filter( token_get_all(file_get_contents($$f)), function($$t){ return($$t[0]==T_DOC_COMMENT); } ) ) ), function($$t){ printf("N_(\"%s\")\n",preg_replace("/\"/","\\\"",$$t)); } ); } );' >> tempCatalog.php
 
 	find . \( -name "*.app" -o -name "*.php" \) -print \
-	| xgettext --no-location --omit-header -f- --keyword='_' --keyword='N_' --keyword='text' --keyword='Text' --language=c --from-code=iso8859-1 -o$(appname)_app_.pot
+	| xgettext --language=PHP \
+	           --from-code=utf-8 \
+	           --no-location \
+	           --keyword='_' \
+	           --keyword='N_' \
+	           --keyword='text' \
+	           --keyword='Text' \
+	           --add-comments=_COMMENT \
+	           --files-from=- \
+	           --output=$(appname)_app.pot
 
 	find . \( -name "*.js" -o -name "*.html" \) -print \
-	| xgettext --no-location --omit-header -f- --keyword='_'  --language=c -o $(appname)_js.pot
+	| xgettext --language=c \
+	           --from-code=utf-8 \
+	           --no-location \
+	           --keyword='_' \
+	           --files-from=- \
+	           --output=$(appname)_js.pot
 
 	php -q $(utildir)/fam2po.php $(podir) $(TRANSFAM);
 
 	echo "LANGS = '$(LANGS)'";
 
-	for lang in  $(LANGS); do \
+	for lang in $(LANGS); do \
 		for fampo in `ls $(podir)/*.pot`; do \
 			filename="$${fampo##*/}"; \
 			basefilename="$${filename%.*}"; \
@@ -186,7 +200,7 @@ po:
 				LC_ALL=fr_FR.UTF-8 msginit --no-translator -i $$fampo -o $(podir)/$${lang}/$${basefilename}_$$lang.po; \
 			fi; \
 			msguniq $$fampo > $(podir)/$${basefilename}_g.pot; \
-			msgmerge -s -v --force-po -N $(podir)/$${lang}/$${basefilename}_$$lang.po $(podir)/$${basefilename}_g.pot  > $(podir)/$${lang}/$${basefilename}_$$lang.po.new; \
+			msgmerge -s -v --force-po -N $(podir)/$${lang}/$${basefilename}_$$lang.po $(podir)/$${basefilename}_g.pot > $(podir)/$${lang}/$${basefilename}_$$lang.po.new; \
 			cp $(podir)/$${lang}/$${basefilename}_$$lang.po.new $(podir)/$${lang}/$${basefilename}_$$lang.po.fam; \
 			mv $(podir)/$${lang}/$${basefilename}_$$lang.po.new $(podir)/$${lang}/$${basefilename}_$$lang.po; \
 			rm -f $(podir)/$${basefilename}_g.pot; \
@@ -194,13 +208,13 @@ po:
 		if [ ! -e $(podir)/$${lang}/$(appname)_$$lang.po ]; then \
 			LC_ALL=fr_FR.UTF-8 msginit --no-translator -i $(appname).pot -o $(podir)/$${lang}/$(appname)_$$lang.po; \
 		fi; \
-		msgcat $(appname)_app_.pot  > $(appname)_tmp_$$lang.pot; \
-		msgmerge -s -v --force-po -N $(podir)/$${lang}/$(appname)_$$lang.po $(appname)_tmp_$$lang.pot  > $(podir)/$${lang}/$(appname)_$$lang.po.new; \
+		msgcat $(appname)_app.pot > $(appname)_tmp_$$lang.pot; \
+		msgmerge -s -v --force-po -N $(podir)/$${lang}/$(appname)_$$lang.po $(appname)_tmp_$$lang.pot > $(podir)/$${lang}/$(appname)_$$lang.po.new; \
 		mv $(podir)/$${lang}/$(appname)_$$lang.po.new $(podir)/$${lang}/$(appname)_$$lang.po; \
 		rm -f $(appname)_tmp_$$lang.pot; \
 		if [ -f $(appname)_js.pot ]; then \
 			if [ -f $(podir)/$${lang}/js_$(appname)_$$lang.po ]; then \
-				msgmerge -s -v --force-po $(podir)/$${lang}/js_$(appname)_$$lang.po $(appname)_js.pot  > $(appname)_js_$$lang.pot; \
+				msgmerge -s -v --force-po $(podir)/$${lang}/js_$(appname)_$$lang.po $(appname)_js.pot > $(appname)_js_$$lang.pot; \
 				mv $(appname)_js_$$lang.pot $(podir)/$${lang}/js_$(appname)_$$lang.po; \
 			else \
 				cp $(appname)_js.pot $(podir)/$${lang}/js_$(appname)_$$lang.po; \
@@ -210,7 +224,7 @@ po:
 			msgcat $(podir)/$${lang}/$(appname)_$$lang.po $(podir)/$${lang}/$(appname)_$$lang.po.fam > $(podir)/$${lang}/$(appname)_$$lang.po.all; \
 			mv $(podir)/$${lang}/$(appname)_$$lang.po.all $(podir)/$${lang}/$(appname)_$$lang.po; \
 		fi; \
-        done \
+	done
 
 	@rm -f tempCatalog.php
 	@rm -f $(appname)*.pot

--- a/PubRule
+++ b/PubRule
@@ -162,11 +162,13 @@ distdir: $(DISTFILES)
 ##----------------------------------------------------
 
 po:
+	echo '<?php' > tempCatalog.php
+	
+	find . -type f -name "*.php" -print0 | xargs -0 php -r 'array_walk( array_slice($$argv,1), function($$f){ array_walk( preg_filter( "/.*@(searchLabel)\\s+([^\\n]+)\\n.*/s", "\\2", array_map( function($$t){ return$$t[1]; }, array_filter( token_get_all(file_get_contents($$f)), function($$t){ return($$t[0]==T_DOC_COMMENT); } ) ) ), function($$t){ printf("N_(\"%s\")\n",preg_replace("/\"/","\\\"",$$t)); } ); } );' >> tempCatalog.php
+	
 	find . \( -name "*.xml" -o -name "*.js" -o -name "*.html" \) -exec \
 	perl -ne 'print "N_(\"$$1\")\n" while(m/\[TEXT:([^]]+)]/g)' {} \; \
-	> tempCatalog.php
-
-	find . -type f -name "*.php" -print0 | xargs -0 php -r 'array_walk( array_slice($$argv,1), function($$f){ array_walk( preg_filter( "/.*@(searchLabel)\\s+([^\\n]+)\\n.*/s", "\\2", array_map( function($$t){ return$$t[1]; }, array_filter( token_get_all(file_get_contents($$f)), function($$t){ return($$t[0]==T_DOC_COMMENT); } ) ) ), function($$t){ printf("N_(\"%s\")\n",preg_replace("/\"/","\\\"",$$t)); } ); } );' >> tempCatalog.php
+	>> tempCatalog.php
 
 	find . \( -name "*.app" -o -name "*.php" \) -print \
 	| xgettext --language=PHP \
@@ -209,12 +211,12 @@ po:
 			LC_ALL=fr_FR.UTF-8 msginit --no-translator -i $(appname).pot -o $(podir)/$${lang}/$(appname)_$$lang.po; \
 		fi; \
 		msgcat $(appname)_app.pot > $(appname)_tmp_$$lang.pot; \
-		msgmerge -s -v --force-po -N $(podir)/$${lang}/$(appname)_$$lang.po $(appname)_tmp_$$lang.pot > $(podir)/$${lang}/$(appname)_$$lang.po.new; \
+		msgmerge -s -v -N $(podir)/$${lang}/$(appname)_$$lang.po $(appname)_tmp_$$lang.pot > $(podir)/$${lang}/$(appname)_$$lang.po.new; \
 		mv $(podir)/$${lang}/$(appname)_$$lang.po.new $(podir)/$${lang}/$(appname)_$$lang.po; \
 		rm -f $(appname)_tmp_$$lang.pot; \
 		if [ -f $(appname)_js.pot ]; then \
 			if [ -f $(podir)/$${lang}/js_$(appname)_$$lang.po ]; then \
-				msgmerge -s -v --force-po $(podir)/$${lang}/js_$(appname)_$$lang.po $(appname)_js.pot > $(appname)_js_$$lang.pot; \
+				msgmerge -s -v $(podir)/$${lang}/js_$(appname)_$$lang.po $(appname)_js.pot > $(appname)_js_$$lang.pot; \
 				mv $(appname)_js_$$lang.pot $(podir)/$${lang}/js_$(appname)_$$lang.po; \
 			else \
 				cp $(appname)_js.pot $(podir)/$${lang}/js_$(appname)_$$lang.po; \


### PR DESCRIPTION
po target now uses php language when extracting keywords.

This allows :
- both `_('…')` and `_("…")` to be used
- inline comments like `// _COMMENT` to be included in generated po

be careful, `#` comments are no more extracted. For workflows or other additional translatable keys, you have to create a separate php file (do not forget to begin it with `<?php`, and give it a `.php` extension)
